### PR TITLE
Tasks now have seperate address spaces

### DIFF
--- a/cpu/i386/kmalloc.c
+++ b/cpu/i386/kmalloc.c
@@ -1,0 +1,92 @@
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stdint.h>
+
+static char bitmap[1048576];
+static void* data=(void*)0xFF400000;
+
+
+static char get_bmap_bit(uint32_t index) {
+  uint32_t byte=index/8;
+  uint32_t bit=index%8;
+  char entry=bitmap[byte];
+  return (entry&(1<<bit))>0;
+}
+
+static void set_bmap_bit(uint32_t index) {
+  uint32_t byte=index/8;
+  uint32_t bit=index%8;
+  bitmap[byte]=bitmap[byte]|(1<<bit);
+}
+
+static void clear_bmap_bit(uint32_t index) {
+  uint32_t byte=index/8;
+  uint32_t bit=index%8;
+  bitmap[byte]=bitmap[byte]&(~(1<<bit));
+}
+
+void* kmalloc(uint32_t size) {
+  uint32_t num_4b_grps=(uint32_t)ceilf((float)size/4);
+  num_4b_grps+=2;
+  uint32_t bmap_index;
+  uint32_t remaining_blks;
+  for(uint32_t i=0;i<2097152;i++) {
+    if (bitmap[i]!=0xFF) {
+      char got_0=0;
+      remaining_blks=num_4b_grps;
+      uint32_t old_j;
+      for (uint32_t j=i*8;;j++) {
+        char bit=get_bmap_bit(j);
+        if (got_0) {
+          if (bit) {
+            if (remaining_blks==0) {
+                bmap_index=old_j;
+                break;
+            } else {
+              i+=j/8;
+              i--;
+              break;
+            }
+          } else {
+            remaining_blks--;
+          }
+        } else {
+          if (!bit) {
+            got_0=1;
+            old_j=j;
+            remaining_blks--;
+          }
+        }
+        if (remaining_blks==0) {
+          bmap_index=old_j;
+          break;
+        }
+      }
+    }
+    if (remaining_blks==0) {
+      break;
+    }
+  }
+  if (remaining_blks!=0) {
+    return NULL;
+  }
+  for (uint32_t i=0;i<num_4b_grps;i++) {
+    set_bmap_bit(bmap_index+i);
+  }
+  uint32_t data_offset=(bmap_index*8)+8;
+  uint32_t* info=(void*)(((uint32_t)data)+data_offset-8);
+  info[0]=num_4b_grps;
+  info[1]=bmap_index;
+  return (void*)(((uint32_t)data)+data_offset);
+
+}
+
+void kfree(void* mem) {
+  uint32_t* info=(uint32_t*)((uint32_t)mem-12);
+  uint32_t num_4b_grps=info[0];
+  uint32_t bmap_index=info[1];
+  for (uint32_t i=0;i<num_4b_grps;i++) {
+    clear_bmap_bit(bmap_index+i);
+  }
+}

--- a/cpu/i386/kmalloc.h
+++ b/cpu/i386/kmalloc.h
@@ -1,0 +1,9 @@
+#ifndef KMALLOC_H
+#define KMALLOC_H
+
+#include <stddef.h>
+
+void* kmalloc(size_t size);
+void kfree(void* mem);
+
+#endif

--- a/cpu/i386/paging.c
+++ b/cpu/i386/paging.c
@@ -103,7 +103,7 @@ void* new_address_space() {
     uint32_t entry_virt=(uint32_t)&(kern_page_tables[i*1024]);
     smap[i+768]=(entry_virt-0xC0000000)|0x7;
   }
-  smap[1021]=(((uint32_t)kmalloc_page_tables)-0xC0000000)|0x3;
+  smap[1021]=(((uint32_t)kmalloc_page_tables)-0xC0000000)|0x7;
   for (uint32_t i=0;i<2;i++) {
     uint32_t entry_virt=(uint32_t)&(smap_page_tables[i*1024]);
     smap[i+1022]=(entry_virt-0xC0000000)|0x3;
@@ -128,7 +128,7 @@ void paging_init() {
     kern_page_tables[i]=(i<<12)|0x7;
   }
   for (uint32_t i=0;i<1024;i++) {
-    kmalloc_page_tables[i]=(uint32_t)pmem_alloc(1)|0x3;
+    kmalloc_page_tables[i]=(uint32_t)pmem_alloc(1)|0x7;
   }
   smap_page_tables[0]=(((uint32_t)&(page_directory))-0xC0000000)|0x3;
   for (uint32_t i=1;i<2048;i++) {
@@ -138,7 +138,7 @@ void paging_init() {
     uint32_t entry_virt=(uint32_t)&(kern_page_tables[i*1024]);
     page_directory[i+768]=(entry_virt-0xC0000000)|0x7;
   }
-  page_directory[1021]=(((uint32_t)kmalloc_page_tables)-0xC0000000)|0x3;
+  page_directory[1021]=(((uint32_t)kmalloc_page_tables)-0xC0000000)|0x7;
   for (uint32_t i=0;i<2;i++) {
     uint32_t entry_virt=(uint32_t)&(smap_page_tables[i*1024]);
     page_directory[i+1022]=(entry_virt-0xC0000000)|0x3;

--- a/cpu/i386/paging.c
+++ b/cpu/i386/paging.c
@@ -109,6 +109,9 @@ void* new_address_space() {
     smap[i+1022]=(entry_virt-0xC0000000)|0x3;
   }
   smap_page_tables[0]=(((uint32_t)&(page_directory))-0xC0000000)|0x3;
+  for (uint32_t i=1;i<2048;i++) {
+    smap_page_tables[i]=0;
+  }
   return dir;
 }
 

--- a/cpu/i386/tasking.c
+++ b/cpu/i386/tasking.c
@@ -42,7 +42,7 @@ static Task* createTaskKmode(void* eip,char kmode) {
     uint32_t cr3;
     asm volatile("movl %%cr3, %%eax; movl %%eax, %0;":"=m"(cr3)::"%eax");
     load_address_space(task->regs.cr3);
-    task->regs.esp=(uint32_t)alloc_memory(1);
+    task->regs.esp=((uint32_t)alloc_memory(1))+0xfff;
     load_address_space(cr3);
     task->regs.ebp=0;
     task->msg_store=NULL;

--- a/cpu/i386/tasking.c
+++ b/cpu/i386/tasking.c
@@ -7,8 +7,8 @@ push %eax; \
 #include "tasking.h"
 #include "../tasking.h"
 #include "isr.h"
-#include "../../libc/stdlib.h"
-#include "../../libc/stdio.h"
+#include <stdio.h>
+#include "kmalloc.h"
 #include "memory.h"
 #include "gdt.h"
 #include <stdint.h>
@@ -28,7 +28,7 @@ void tasking_init() {
 }
 
 static Task* createTaskKmode(void* eip,char kmode) {
-    Task* task=malloc(sizeof(Task));
+    Task* task=kmalloc(sizeof(Task));
     task->kmode=kmode;
     task->regs.eax=0;
     task->regs.ebx=0;

--- a/cpu/i386/tasking.c
+++ b/cpu/i386/tasking.c
@@ -123,7 +123,7 @@ void tasking_yield() {
     }
     Task* oldCurr=currentTask;
     currentTask=task;
-    // load_address_space(task->regs.cr3);
+    load_address_space(task->regs.cr3);
     if (!task->kmode) {
       asm volatile("  \
         cli; \


### PR DESCRIPTION
NOTE: All task structures are user read/writable to allow switchTask to save and load the registers

I found that all tasks were running in kernel mode, so that has been fixed.

Fixes #18